### PR TITLE
Ignoring .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Vagrant
 .vagrant
+
+# DS_Store files
+.DS_Store
+


### PR DESCRIPTION
Adding .DS_Store files to .gitignore.
.DS_Store files are created automatically by mac OS and aren't needed to include in the project files.