### PR TITLE
🏇 Flake8: Add `tox.ini` To Ignore `venv`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[flake8]
+ignore = D203
+exclude =
+    venv
+max-complexity = 10


### PR DESCRIPTION
**INFO:**

Once you [use *Flake8* along your code][1],
the *Flake8* will also run its checks on a folder
called `venv`. Though, the `venv` is not needed
to be scanned in the first place.

Flake8 supports storing its configuration in your
project in one of `setup.cfg`, `tox.ini`, or `.flake8`.
As shown [here][2].

**What Changes Were Made:**

- Added a `tox.ini` file to configure *Flake8* to
  ignore scanning the `venv` folder.
  > This is done based on the [official guide from *Flake8*][3]
  > for ignoring files / folders.

[1]: https://github.com/redhat-beyond/JobSeeker/blob/main/docs/Flake8.md#How-To-Use-Flake8-Along-Your-Code
[2]: https://flake8.pycqa.org/en/latest/user/configuration.html#:~:text=Flake8%20supports%20storing%20its%20configuration%20in%20your%20project%20in%20one%20of%20setup.cfg%2C%20tox.ini%2C%20or%20.flake8.
[3]: https://flake8.pycqa.org/en/latest/user/configuration.html#:~:text=%5Bflake8%5D%0Aignore%20%3D%20D203%0Aexclude%20%3D%0A%20%20%20%20.git%2C%0A%20%20%20%20__pycache__%2C%0A%20%20%20%20docs/source/conf.py%2C%0A%20%20%20%20old%2C%0A%20%20%20%20build%2C%0A%20%20%20%20dist%0Amax%2Dcomplexity%20%3D%2010

---

Close #42 

Signed-off-by: Tal Jacob <taljacob2@gmail.com>