### PR TITLE
🏇  Improve Base Template: Set The Footer To Bottom of Page

### DIFF
--- a/jobseeker/templates/jobseeker/base_template.html
+++ b/jobseeker/templates/jobseeker/base_template.html
@@ -19,7 +19,7 @@
     {% endif %}
 
   </head>
-  <body>
+  <body class="d-flex flex-column min-vh-100">
     <div class="container">
       <header class="site-header">
         <nav class="navbar fixed-top navbar-expand-lg navbar-light">
@@ -58,7 +58,7 @@
       </div>
     </main>
     
-    <footer class="page-footer boarder-top py-3">
+    <footer class="page-footer boarder-top py-3 mt-auto">
       <div class="row">
         <div class="col">
           <img class="mx-auto d-block" src="{% static 'jobseeker/main_logo.png' %}" alt="logo">


### PR DESCRIPTION
Set the footer to always appear at the bottom of the webpage by adding several bootstrap classes to the body tag and to the footer tag.

Example webpage:
![Screen Shot 2022-04-13 at 21 47 19](https://user-images.githubusercontent.com/99258236/163249288-5ed03b04-a89b-4bed-9ec3-6cc8064c91b4.png)

Close #97 
