### PR TITLE
🚀  Post Detail View

### DIFF
--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -1,0 +1,6 @@
+{% extends "jobseeker/base_template.html" %}
+{% block content %}
+    <div class="pt-5">
+        {% include "feed/post.html" %}
+    </div>
+{% endblock content %}

--- a/feed/tests/test_feed_views.py
+++ b/feed/tests/test_feed_views.py
@@ -1,0 +1,47 @@
+import pytest
+from feed.models import Post
+from django.contrib.auth.models import User
+
+
+USERNAME = 'username'
+USER_PASS = 'secret_pass'
+POST_TITLE = 'post title'
+POST_CONTENT = 'some post content'
+POST_DETAIL_URL = '/post/'
+PAGE_NOT_FOUND = 404
+
+
+@pytest.fixture
+def user(db):
+    user = User.objects.create_user(USERNAME, password=USER_PASS)
+    return user
+
+
+@pytest.fixture
+def post(db, user):
+    post = Post.posts.create(title=POST_TITLE, content=POST_CONTENT, author=user)
+    post.save()
+    return post
+
+
+@pytest.mark.django_db
+class TestPostDetailView:
+    def test_detail_view_page_entrypoint(self, post, client):
+        # Testing to see if a valid post id gets a valid detail view page
+        response = client.get(POST_DETAIL_URL + str(post.id) + '/')
+        assert response.status_code == 200
+
+    def test_detail_view_returned_data(self, post, client):
+        # Testing that the returned post really is the one
+        # that it ID has passed through the URL
+        response = client.get(POST_DETAIL_URL + str(post.id) + '/')
+        assert response.context['post'].id == post.id
+
+    def test_detail_view_page_for_invalid_post_id(self, client):
+        # Testing to see if for an invalid post id, the response will be 404
+        # The id's start from 1 and increases by 1 for each post, so the last post will
+        # get the id of the number of posts, so by adding 1 we promise that it will be
+        # an invalid ID
+        max_post_id = Post.posts.all().count()
+        response = client.get(POST_DETAIL_URL + str(max_post_id + 1) + '/')
+        assert response.status_code == PAGE_NOT_FOUND

--- a/feed/urls.py
+++ b/feed/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.feed, name='feed'),
+    path('post/<int:pk>/', views.PostDetailView.as_view(), name='post-detail'),
 ]

--- a/feed/views.py
+++ b/feed/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from .models import Post
+from django.views.generic import DetailView
 
 
 def feed(request):
@@ -8,3 +9,7 @@ def feed(request):
         'title': 'Feed'
     }
     return render(request, 'feed/feed.html', context)
+
+
+class PostDetailView(DetailView):
+    model = Post


### PR DESCRIPTION
Adding a detail view for post model.
Each post will get a unique url that will only show the post itself and let the user to interact with it.
Each post detail view url will be `/post/post_id/` where `post_id`  should be replaced with the desire post id.

- Added a post detail view html template
- Set up detail view for posts via `views.py` file, used Django's DetailView class
- Set up the post detail view URL
- Added tests

The post detail view screenshot:
![Screen Shot 2022-04-15 at 10 57 14](https://user-images.githubusercontent.com/99258236/163543816-8ace53b2-998b-410d-8ff9-b41737cdd099.png)

Close #115 