### PR TITLE
🚀 Job Board: Add search results view

### DIFF
--- a/job_board/search_form.py
+++ b/job_board/search_form.py
@@ -1,0 +1,9 @@
+from django import forms
+from job_board.models.preference import Preference
+
+
+class SearchForm(forms.ModelForm):
+
+    class Meta:
+        model = Preference
+        fields = ('job_type', 'location', 'years_of_experience', 'work_schedule')

--- a/job_board/templates/job_board/job_board.html
+++ b/job_board/templates/job_board/job_board.html
@@ -2,8 +2,12 @@
 {% block content %}
     <div class="search_bar">
         <h2>Job Board</h2>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" value="search">
+        </form>
     </div>
     <div class="search_results">
-        <h2></h2>
     </div>
 {% endblock content %}

--- a/job_board/templates/job_board/job_board.html
+++ b/job_board/templates/job_board/job_board.html
@@ -1,4 +1,9 @@
 {% extends "jobseeker/base_template.html" %}
 {% block content %}
-    <h1>Job Board</h1>
+    <div class="search_bar">
+        <h2>Job Board</h2>
+    </div>
+    <div class="search_results">
+        <h2></h2>
+    </div>
 {% endblock content %}

--- a/job_board/templates/job_board/job_board.html
+++ b/job_board/templates/job_board/job_board.html
@@ -9,5 +9,10 @@
         </form>
     </div>
     <div class="search_results">
+        {% if results%}
+            {% for post in results %}
+                {% include "job_board/post.html" %}
+            {% endfor %}
+        {% endif %}
     </div>
 {% endblock content %}

--- a/job_board/templates/job_board/post.html
+++ b/job_board/templates/job_board/post.html
@@ -1,0 +1,22 @@
+{% load static %}
+<div class="mb-5 container d-flex justify-content-center" 
+    style="margin-top: revert !important; margin-bottom: revert !important; padding-left: 0%; padding-right: 0%;">
+    <div class="card" style="min-width: 100%;">
+        <div class="card-body pb-1">
+            <div class="d-flex pb-2">
+                <div>
+                    <a href="" class="text-dark">
+                        <strong>{{ post.author }}</strong>
+                    </a>
+                    <p class="text-muted d-block" style="margin-top: 0 !important; margin-bottom: 0 !important;">
+                        <small>{{ post.date_posted }}</small>
+                </div>
+            </div>
+
+            <!-- Description -->
+            <div>
+                <h5>{{post.title}}</h3>
+            </div>
+        </div>
+    </div>
+</div>

--- a/job_board/templates/job_board/post.html
+++ b/job_board/templates/job_board/post.html
@@ -15,7 +15,7 @@
 
             <!-- Description -->
             <div>
-                <h5>{{post.title}}</h3>
+                <h5><a href="{% url 'post-detail' post.id %}">{{post.title}}</a></h3>
             </div>
         </div>
     </div>

--- a/job_board/tests.py
+++ b/job_board/tests.py
@@ -55,9 +55,3 @@ class TestJobBoardModels:
 
         preference.delete()
         assert preference not in Preference.objects.all()
-
-
-class TestJobBoardURLs:
-    def test_job_board_app_entrypoint(self, client):
-        response = client.get("/job_board/")
-        assert response.status_code == 200

--- a/job_board/tests/test_search_form.py
+++ b/job_board/tests/test_search_form.py
@@ -1,0 +1,69 @@
+from job_board.search_form import SearchForm
+from django.test import RequestFactory
+import pytest
+
+valid_form_datas = [
+    {
+        'job_type': '1',
+        'location': '1',
+        'years_of_experience': '0-2 years',
+        'work_schedule': 'Flexible'
+    },
+    {
+        'job_type': '3',
+        'location': '2',
+        'years_of_experience': '5+ years',
+        'work_schedule': 'Not specified'
+    }
+]
+
+invalid_form_datas = [
+    {
+        'job_type': '100'
+    },
+    {
+        'job_type': '-3',
+        'location': '2',
+        'years_of_experience': '5+ years',
+        'work_schedule': 'Not specified'
+    }
+]
+job_board_url = '/job_board/'
+
+
+@pytest.fixture
+def create_valid_form_instances():
+    request1 = RequestFactory().post(job_board_url, valid_form_datas[0])
+    form1 = SearchForm(request1.POST)
+    request2 = RequestFactory().post(job_board_url, valid_form_datas[1])
+    form2 = SearchForm(request2.POST)
+
+    return [form1, form2]
+
+
+@pytest.fixture
+def create_invalid_form_instances():
+    request1 = RequestFactory().post(job_board_url, invalid_form_datas[0])
+    form1 = SearchForm(request1.POST)
+    request2 = RequestFactory().post(job_board_url, invalid_form_datas[1])
+    form2 = SearchForm(request2.POST)
+
+    return [form1, form2]
+
+
+@pytest.mark.django_db
+class TestSearchForm():
+
+    def test_search_valid_form(self, create_valid_form_instances):
+        form1 = create_valid_form_instances[0]
+        form2 = create_valid_form_instances[1]
+
+        assert form1.is_valid()
+        assert form2.is_valid()
+
+    def test_search_invalid_form(self, create_invalid_form_instances):
+        form1 = create_invalid_form_instances[0]
+        form2 = create_invalid_form_instances[1]
+
+        assert not form1.is_valid()
+        assert not form2.is_valid()

--- a/job_board/tests/test_urls.py
+++ b/job_board/tests/test_urls.py
@@ -1,0 +1,11 @@
+from job_board.views import AddSearchView
+from django.test import RequestFactory
+import pytest
+
+
+@pytest.mark.django_db
+class TestJobBoardURLs:
+    def test_job_board_app_entrypoint(self, client):
+        request = RequestFactory().get('/job_board/')
+        response = AddSearchView.as_view()(request)
+        assert response.status_code == 200

--- a/job_board/urls.py
+++ b/job_board/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 
 urlpatterns = [
-    path('job_board/', views.job_board, name='job_board'),
+    path('job_board/', views.AddSearchView.as_view(), name='job_board'),
 ]

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -1,6 +1,27 @@
 from django.shortcuts import render
+from django.views.generic.edit import FormView
+from .search_form import SearchForm
 
 
-def job_board(request):
-    context = {'title': 'Job Board'}
-    return render(request, 'job_board/job_board.html', context)
+class AddSearchView(FormView):
+
+    template_name = 'job_board/job_board.html'
+    form_class = SearchForm
+    success_url = '/job_board/'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['title'] = 'Job Board'
+        return context
+
+    def get(self, request, *args, **kwargs):
+        form = self.form_class(initial=self.initial)
+        context = {'title': 'Job Board', 'form': form}
+        return render(request, self.template_name, context)
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST)
+        if form.is_valid():
+            context = {'title': 'Job Board', 'results': form.cleaned_data, 'form': form}
+
+        return render(request, 'job_board/job_board.html', context)

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.views.generic.edit import FormView
 from .search_form import SearchForm
+from feed.models.post import Post
 
 
 class AddSearchView(FormView):
@@ -22,6 +23,6 @@ class AddSearchView(FormView):
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
         if form.is_valid():
-            context = {'title': 'Job Board', 'results': form.cleaned_data, 'form': form}
+            context = {'title': 'Job Board', 'results': Post.posts.filter(is_job_offer=True), 'form': form}
 
         return render(request, 'job_board/job_board.html', context)

--- a/jobseeker/static/jobseeker/job_board.css
+++ b/jobseeker/static/jobseeker/job_board.css
@@ -1,0 +1,13 @@
+
+.search_bar {
+    display: inline;
+    float: left;
+    background-color: #7DA3A1;
+    width: 40%;
+}
+
+.search_results {
+  display: inline;
+  float: left;
+  width: 60%;
+}

--- a/jobseeker/templates/jobseeker/base_template.html
+++ b/jobseeker/templates/jobseeker/base_template.html
@@ -11,6 +11,7 @@
     
     <!-- Job Seeker CSS -->
     <link rel="stylesheet" type="text/css" href="{% static 'jobseeker/main.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'jobseeker/job_board.css' %}">
 
     {% if title %}
       <title>Job Seeker - {{ title }}</title>


### PR DESCRIPTION
- Added the results of the search to the job_board.html.
- Linked each result to its relevant page.
- Screenshot of the webpage after search:
![1](https://user-images.githubusercontent.com/83355266/164345275-777ac6d3-88a1-4d8a-a65f-09493484b72a.png)

Depends on #122
Close #126 
Close #130 

Notes: 
- Until the search engine is implemented, all posts with job offers will be returned when searching.
- Difference between this PR and #122 is the last 2 commits
