### PR TITLE
:bug:Job board: Fixing experience level not showing issue

### DIFF
--- a/feed/templates/feed/post.html
+++ b/feed/templates/feed/post.html
@@ -38,7 +38,7 @@
                 {% if post.is_job_offer %}
                     <p>
                         <b>Job Type:</b> {{ post.prefernces.job_type.text }} <br>
-                        <b>Experience Level:</b> {{ post.prefernces.years_of_experience.text }} <br>
+                        <b>Experience Level:</b> {{ post.prefernces.years_of_experience }} <br>
                         <b>Location:</b> {{ post.prefernces.location.name }}
                     </p>
                 {% endif %}


### PR DESCRIPTION
Currently, years of experience were missing from the posts in the job board.

Before fix:
![Screenshot 2022-05-23 105301](https://user-images.githubusercontent.com/94441055/169771526-e892c2fe-b31c-40cc-9ea4-b08f8defb3ab.png)


After fix:
![Screenshot 2022-05-23 105238](https://user-images.githubusercontent.com/94441055/169771347-4a84a419-ab6d-4a89-8f25-2c25ce3cd9a9.png)




